### PR TITLE
Fix spell checker saving

### DIFF
--- a/src/main/java/com/xelitexirish/elitedeveloperbot/commands/SpellCheckerCommand.java
+++ b/src/main/java/com/xelitexirish/elitedeveloperbot/commands/SpellCheckerCommand.java
@@ -15,10 +15,10 @@ public class SpellCheckerCommand implements ICommand{
 
         if(args.length == 1){
             if(args[0].equalsIgnoreCase("false")){
-                SpellCheckerListener.blockUser(event.getGuild(), event.getAuthor());
+                SpellCheckerListener.blockUser(event.getGuild(), event.getAuthor(), event.isPrivate());
 
             }else if (args[0].equalsIgnoreCase("true")){
-                SpellCheckerListener.unblockUser(event.getGuild(), event.getAuthor());
+                SpellCheckerListener.unblockUser(event.getGuild(), event.getAuthor(), event.isPrivate());
             }
         }
     }

--- a/src/main/java/com/xelitexirish/elitedeveloperbot/listeners/SpellCheckerListener.java
+++ b/src/main/java/com/xelitexirish/elitedeveloperbot/listeners/SpellCheckerListener.java
@@ -26,6 +26,8 @@ public class SpellCheckerListener {
 
     public static void init() {
         fillWordLists();
+        blackListUsers.clear();
+        loadBlackListData();
     }
 
     public static void handleMessage(MessageReceivedEvent event) {
@@ -87,7 +89,7 @@ public class SpellCheckerListener {
         loadBlackListData();
     }
 
-    public static void blockUser(Guild guild, User user) {
+    public static void blockUser(Guild guild, User user, Boolean privateMsg) {
         String userId = user.getId();
 
         blackListUsers.clear();
@@ -99,13 +101,18 @@ public class SpellCheckerListener {
         } else {
             blackListUsers.add(userId);
             user.getPrivateChannel().sendMessage("You are now on the bot blacklist. Use '" + Constants.COMMAND_PREFIX + "correction false' to unblock yourself.");
-            guild.getPublicChannel().sendMessage(MessageUtils.wrapStringInCodeBlock("User setting updated"));
+            if(privateMsg){
+                user.getPrivateChannel().sendMessage(MessageUtils.wrapStringInCodeBlock("User setting updated"));
+            }else{
+                guild.getPublicChannel().sendMessage(MessageUtils.wrapStringInCodeBlock("User setting updated"));
+            }
+
         }
 
         writeBlacklist();
     }
 
-    public static void unblockUser(Guild guild, User user) {
+    public static void unblockUser(Guild guild, User user, Boolean privateMsg) {
         String userId = user.getId();
 
         blackListUsers.clear();
@@ -114,8 +121,11 @@ public class SpellCheckerListener {
         if (blackListUsers.contains(userId)) {
             blackListUsers.remove(userId);
             user.getPrivateChannel().sendMessage("You are now removed from the bot blacklist. Use '" + Constants.COMMAND_PREFIX + "correction false' to block yourself.");
-            guild.getPublicChannel().sendMessage(MessageUtils.wrapStringInCodeBlock("User setting updated"));
-
+            if(privateMsg){
+                user.getPrivateChannel().sendMessage(MessageUtils.wrapStringInCodeBlock("User setting updated"));
+            }else{
+                guild.getPublicChannel().sendMessage(MessageUtils.wrapStringInCodeBlock("User setting updated"));
+            }
         } else {
             user.getPrivateChannel().sendMessage("You are currently not on the blacklist. Use '" + Constants.COMMAND_PREFIX + "correction false' to block yourself.");
         }


### PR DESCRIPTION
Will fix the `!dev correction false` and `!dev correction true` not correctly saving (throwing exception because it can't get the guild's public channel as it is a PM) in personal messages.
